### PR TITLE
Removes index.html & popup.html from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,3 @@ nod
 node_modules
 package-lock.json
 .vscode
-src/pages/options/index.html
-src/pages/popup/popup.html


### PR DESCRIPTION
I noticed this was left out of the previous commit.

Could you also push this update to [the Firefox Add-ons site](https://addons.mozilla.org/en-US/firefox/addon/i2p-unofficial/) so that regular users can get the fix as well?

Thank you!